### PR TITLE
Redate fix run

### DIFF
--- a/Redate/FileCollectionInfoData.cs
+++ b/Redate/FileCollectionInfoData.cs
@@ -25,8 +25,8 @@ namespace Redate
 
 		public FileInfoData[] Files { get; set; } = null;
 
-		[JsonIgnore]
-		public required ISimpleLog Log { get; set; }
+		// The `Log` member was serialized before.
+		// Therefore, to stay compatible with old files, this member name must never be used again.
 
 		internal void Collect(string[] sourceDirs)
 		{
@@ -69,7 +69,7 @@ namespace Redate
 		/// </summary>
 		/// <param name="files"></param>
 		/// <returns>True if the information of any file has been updated</returns>
-		internal bool Update(FileCollectionInfoData files)
+		internal bool Update(FileCollectionInfoData files, ISimpleLog Log)
 		{
 			bool retval = false;
 			// this is the old/known state

--- a/Redate/Program.cs
+++ b/Redate/Program.cs
@@ -47,7 +47,7 @@ namespace Redate
 						{
 							log.Write("Collecting Data");
 							string targetDir = System.IO.Path.GetDirectoryName(cmd.RedateFile) + '\\';
-							FileCollectionInfoData files = new FileCollectionInfoData() { Log = log };
+							FileCollectionInfoData files = new FileCollectionInfoData();
 							files.Collect(cmd.SourceDirs);
 							files.SourceDirsToRelative(targetDir);
 
@@ -73,19 +73,18 @@ namespace Redate
 						{
 							log.Write("Loading " + System.IO.Path.GetFileName(cmd.RedateFile));
 							FileCollectionInfoData knownFiles = JsonConvert.DeserializeObject<FileCollectionInfoData>(System.IO.File.ReadAllText(cmd.RedateFile));
-							knownFiles.Log = log;
 							string targetDir = System.IO.Path.GetDirectoryName(cmd.RedateFile) + '\\';
 							knownFiles.SourceDirsToAbsolute(targetDir);
 							foreach (var f in knownFiles.Files) f.PathToAbsolute(targetDir);
 
 							log.Write("Collecting Data");
-							FileCollectionInfoData files = new FileCollectionInfoData() { Log = log };
+							FileCollectionInfoData files = new FileCollectionInfoData();
 							files.Collect(knownFiles.SourceDirs);
 							log.Write("Compute MD5s");
 							foreach (var f in files.Files) f.ComputeMd5Hash();
 
 							log.Write("Updating");
-							bool isUpdated = knownFiles.Update(files);
+							bool isUpdated = knownFiles.Update(files, log);
 
 							if (isUpdated || cmd.ForceFileDateUpdate)
 							{

--- a/Redate/README.md
+++ b/Redate/README.md
@@ -117,7 +117,7 @@ If not, trigger _Restore Nuget Packages_ on the solution, e.g. by right-clicking
 ## License
 This project is dual licensed. You choose either the terms of the [MIT LICENSE](../LICENSE) or the [Apache LICENSE v2.0](./LICENSE).
 
-> Copyright 2021-2024 SGrottel (https://www.sgrottel.de)
+> Copyright 2021-2025 SGrottel (https://www.sgrottel.de)
 > 
 > Licensed under the Apache License, Version 2.0 (the "License");
 > you may not use this file except in compliance with the License.

--- a/Redate/Redate.csproj
+++ b/Redate/Redate.csproj
@@ -6,8 +6,8 @@
     <ApplicationIcon>images\redate.ico</ApplicationIcon>
     <Authors>SGrottel</Authors>
     <Description>Rewrite dates of files</Description>
-    <Copyright>Copyright 2021 SGrottel (https://www.sgrottel.de)</Copyright>
-    <Version>1.2.0</Version>
+    <Copyright>Copyright 2021-2025 SGrottel (https://www.sgrottel.de)</Copyright>
+    <Version>1.3.0</Version>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
The "run" command was broken because the file serialization included a ISimpleLog object, which cannot be deserialized.